### PR TITLE
Fix CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 node_modules
+package-lock.json
 .pnp
 .pnp.js
 

--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ ESLINT=node_modules/eslint/bin/eslint.js
 PRETTIER=node_modules/prettier/bin-prettier.js
 
 node_modules:
-	npm install clang-format prettier css-validator eslint eslint-config-google
+	npm install clang-format prettier css-validator eslint eslint-config-google react-scripts
 
 pretty: node_modules
 	$(PRETTIER) --write portfolio/frontend/src/*.css


### PR DESCRIPTION
Adds missing dependencies in makefile-generated node_modules.
Also adds the root package-lock to the gitignore, since it will be re-created every time the tests run anyway. 