### PR TITLE
Bug fixes and improvements in compselect page 

### DIFF
--- a/project/frontend/src/App.js
+++ b/project/frontend/src/App.js
@@ -85,6 +85,7 @@ function App() {
           <HeaderBar
             loggedIn={user.signedIn}
             innerNav={compId != 0}
+            compIdChanged={setCompId}
           ></HeaderBar>
           <Layout>{pageRoute}</Layout>
         </AuthContext.Provider>

--- a/project/frontend/src/components/CompetitionCard/CompetitionCard.module.css
+++ b/project/frontend/src/components/CompetitionCard/CompetitionCard.module.css
@@ -15,7 +15,7 @@
 }
 
 .CompetitionCardContainer:hover {
-  transform: scale(1.1);
+  transform: scale(1.05);
 }
 
 .CompetitionInfoContainer {

--- a/project/frontend/src/components/HeaderBar/HeaderBar.js
+++ b/project/frontend/src/components/HeaderBar/HeaderBar.js
@@ -31,7 +31,7 @@ const HeaderBar = (props) => {
 
   const clearCompId = () => {
     localStorage.setItem("compId", 0);
-    props.compIdChange(0);
+    props.compIdChanged(0);
   };
 
   let buttonSet = props.loggedIn ? (

--- a/project/frontend/src/containers/SelectCompetition/SelectCompetition.js
+++ b/project/frontend/src/containers/SelectCompetition/SelectCompetition.js
@@ -17,6 +17,14 @@ const SelectCompetition = (props) => {
   };
 
   const renderCompCards = (compsList) => {
+    if (compsList.length === 0) {
+      setComps(
+        <p className={classes.NoCompetition}>
+          Welp, you have no competitions... D:
+        </p>
+      );
+      return;
+    }
     setComps(
       compsList.map((comp) => {
         return (

--- a/project/frontend/src/containers/SelectCompetition/SelectCompetition.js
+++ b/project/frontend/src/containers/SelectCompetition/SelectCompetition.js
@@ -20,7 +20,7 @@ const SelectCompetition = (props) => {
     if (compsList.length === 0) {
       setComps(
         <p className={classes.NoCompetition}>
-          You are not currently enrolled in any competitions... D:
+          You're not currently enrolled in any competitions... D:
         </p>
       );
       return;

--- a/project/frontend/src/containers/SelectCompetition/SelectCompetition.js
+++ b/project/frontend/src/containers/SelectCompetition/SelectCompetition.js
@@ -20,7 +20,7 @@ const SelectCompetition = (props) => {
     if (compsList.length === 0) {
       setComps(
         <p className={classes.NoCompetition}>
-          Welp, you have no competitions... D:
+          You are not currently enrolled in any competitions... D:
         </p>
       );
       return;

--- a/project/frontend/src/containers/SelectCompetition/SelectCompetition.module.css
+++ b/project/frontend/src/containers/SelectCompetition/SelectCompetition.module.css
@@ -40,25 +40,6 @@
   display: none; /* Safari and Chrome */
 }
 
-.menu-item {
-  padding: 0 40px;
-  margin: 5px 10px;
-  user-select: none;
-  cursor: pointer;
-  border: none;
-}
-.menu-item-wrapper.active {
-  border: 1px blue solid;
-}
-.menu-item.active {
-  border: 1px green solid;
-}
-
-.scroll-menu-arrow {
-  padding: 20px;
-  cursor: pointer;
-}
-
 .NoCompetition {
   margin: auto;
   font-weight: 300;

--- a/project/frontend/src/containers/SelectCompetition/SelectCompetition.module.css
+++ b/project/frontend/src/containers/SelectCompetition/SelectCompetition.module.css
@@ -17,6 +17,8 @@
   width: 100%;
   display: flex;
   align-items: center;
+  border-top: 1px solid lightgray;
+  border-bottom: 1px solid lightgray;
 }
 
 .CardsContainer ul {
@@ -55,4 +57,9 @@
 .scroll-menu-arrow {
   padding: 20px;
   cursor: pointer;
+}
+
+.NoCompetition {
+  margin: auto;
+  font-weight: 300;
 }


### PR DESCRIPTION
* "Select Competition" in header bar wasn't working properly - fixed this 
* Reduced the on hover scaling of competition cards - this is to accomodate for larger screens (hover effect was making cards overlap before). 
Please note that the app is NOT responsive at this stage, it is currently designed for screens of size 1080px and hence will look that size 
* Added a display message for when the user is entered in no competitions (used to just display blank) 
* Removed css that was no longer needed
