### PR TITLE
Fix the bug where backend tries to retrieve today's data even when it doesn't exist

### DIFF
--- a/project/scripts/fetch_trends.py
+++ b/project/scripts/fetch_trends.py
@@ -72,7 +72,8 @@ def aggregate_hourly_to_daily(hourly_df):
     search_term = hourly_df.columns[0]
     new_data = {
         "search_term": search_term,
-        "initial_date": date_to_epoch(hourly_df.index[0])
+        "initial_date": date_to_epoch(hourly_df.index[0]),
+        "latest_date": date_to_epoch(hourly_df.index[1])
     }
     count = 0
     day_total = 0

--- a/project/src/main/java/com/google/sps/servlets/InvestmentCalculator.java
+++ b/project/src/main/java/com/google/sps/servlets/InvestmentCalculator.java
@@ -108,7 +108,7 @@ public class InvestmentCalculator {
 
         //store dates as long to prevent y2k in 2038 but immediately convert to string for datastore reasons
         String startDate = (investDate / 1000L) + "";
-        String currentDate = getLatestUpdatedDateForSearch(googleSearch).toString();
+        String latestAvailableDate = getLatestUpdatedDateForSearch(googleSearch).toString();
 
         Entity trend;
         float startValue;
@@ -118,7 +118,7 @@ public class InvestmentCalculator {
         while (trends.hasNext()) {
             trend = trends.next();
             startValue = (float) trend.getLong(startDate);
-            endValue = (float) trend.getLong(currentDate);
+            endValue = (float) trend.getLong(latestAvailableDate);
             investmentValue = amtInvested * (endValue / startValue);
         }
         return (int) investmentValue;

--- a/project/src/main/java/com/google/sps/servlets/InvestmentServlet.java
+++ b/project/src/main/java/com/google/sps/servlets/InvestmentServlet.java
@@ -108,7 +108,7 @@ public class InvestmentServlet extends HttpServlet {
 
   private ImmutableList<Long> getInvestmentDataPoints(String searchQuery, long investDate, long sellDate) {
     InvestmentCalculator calc = new InvestmentCalculator();
-    List<String> dates = calc.getListOfDates(investDate, sellDate);
+    List<String> dates = calc.getListOfDates(investDate, sellDate, searchQuery);
     Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
 
     Query<Entity> query = Query.newEntityQueryBuilder()
@@ -130,19 +130,5 @@ public class InvestmentServlet extends HttpServlet {
       return ImmutableList.copyOf(values);
     }
     return ImmutableList.copyOf(values);
-  }
-
-  /**
-   * Return epoch exactly 3 days before given date
-   */
-  private Long threeDaysBefore(long date) {
-    return date - LAST_THREE_DAYS_SECONDS;
-  }
-
-  /**
-   * Return epoch exactly one day after given date
-   */
-  private Long addOneDay(long date) {
-    return date + ONE_DAY_SECONDS;
   }
 }


### PR DESCRIPTION
 - add latest_date parameter in data uploaded by Python script to show the last date for which data is inserted
 - Update investment calculator to use this date, rather than today's date as the current date to fetch data up to