### PR TITLE
Refactor of frontend: auth flow, useeffects, loading data, routing... 

### DIFF
--- a/project/frontend/src/App.js
+++ b/project/frontend/src/App.js
@@ -49,15 +49,9 @@ function App() {
   };
 
   const isReadyForDataFetch = () => {
-    if (!user.signedIn) {
-      return false;
-    }
-    if (user.id === undefined) {
-      return false;
-    }
-    if (compId === 0) {
-      return false;
-    }
+    if (!user.signedIn) return false;
+    if (user.id === undefined) return false;
+    if (compId === 0) return false;
     return true;
   };
 
@@ -84,8 +78,6 @@ function App() {
         fetchCompetitionInfo("./trending", "trending"),
       ]).then((resolvedData) => {
         setLoading(false);
-        console.log(resolvedData);
-        console.log(competitionInfo);
         let newCompInfo = {};
         for (const response of resolvedData) {
           newCompInfo = {
@@ -97,17 +89,6 @@ function App() {
       });
     }
   }, [user.id, authStateReceived]);
-
-  let pageRoute = (
-    <PageRouter
-      signedIn={user.signedIn}
-      compId={compId}
-      loading={loading}
-      compIdChanged={setCompId}
-      competitionInfo={competitionInfo}
-      updateCompId={setCompId}
-    />
-  );
 
   return (
     <BrowserRouter>
@@ -121,7 +102,16 @@ function App() {
           {!authStateReceived ? (
             <div>Signing in...</div>
           ) : (
-            <Layout>{pageRoute}</Layout>
+            <Layout>
+              <PageRouter
+                signedIn={user.signedIn}
+                compId={compId}
+                loading={loading}
+                compIdChanged={setCompId}
+                competitionInfo={competitionInfo}
+                updateCompId={setCompId}
+              />
+            </Layout>
           )}
         </AuthContext>
       </div>

--- a/project/frontend/src/App.js
+++ b/project/frontend/src/App.js
@@ -1,21 +1,13 @@
 import "./App.css";
 import React, { useState, useEffect } from "react";
-import { Route, Switch, Redirect, BrowserRouter } from "react-router-dom";
-
-import Explanation from "./containers/Explanation/Explanation";
-import SelectCompetition from "./containers/SelectCompetition/SelectCompetition";
+import { BrowserRouter } from "react-router-dom";
 
 import HeaderBar from "./components/HeaderBar/HeaderBar";
-import LandingPage from "./containers/LandingPage/LandingPage";
-import Dashboard from "./containers/Dashboard/Dashboard";
-import Competition from "./containers/Competition/Competition";
-import MySGonks from "./containers/MySGonks/MySGonks";
-
 import Layout from "./hoc/Layout/Layout";
+import PageRouter from "./hoc/PageRouter/PageRouter";
+
 import { AuthContext } from "./context/AuthContext";
 import { onAuthStateChange } from "./services/firebase";
-import Marketplace from "./containers/Marketplace/Marketplace";
-import PageRouter from "./hoc/PageRouter/PageRouter";
 
 export const NO_COMPETITION = 0;
 

--- a/project/frontend/src/App.js
+++ b/project/frontend/src/App.js
@@ -1,5 +1,5 @@
 import "./App.css";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Route, Switch, Redirect, BrowserRouter } from "react-router-dom";
 
 import Explanation from "./containers/Explanation/Explanation";
@@ -25,7 +25,7 @@ function App() {
   const [competitionInfo, setCompetitionInfo] = useState({});
   const [loading, setLoading] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const unsubscribe = onAuthStateChange((userData) => {
       setUser(userData);
       setAuthStateReceived(true);
@@ -36,7 +36,7 @@ function App() {
     };
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const parsedCompId = Number(localStorage.getItem("compId") || 0);
     setCompId(parsedCompId);
   }, []);
@@ -55,7 +55,7 @@ function App() {
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!authStateReceived) {
       return;
     }

--- a/project/frontend/src/App.js
+++ b/project/frontend/src/App.js
@@ -64,15 +64,15 @@ function App() {
       setLoading(true),
         Promise.all([
           fetchCompetitionInfo(
-            "./competitionInfo?user=" + user.id + "&competition=" + compId,
+            `./competitionInfo?user=${user.id}&competition=${compId}`,
             "generalInfo"
           ),
           fetchCompetitionInfo(
-            "./recentBuys?competition=" + compId,
+            `./recentBuys?competition=${compId}`,
             "recentBuys"
           ),
           fetchCompetitionInfo(
-            "./investments?user=" + user.id + "&competition=" + compId,
+            `./investments?user=${user.id}&competition=${compId}`,
             "investments"
           ),
           fetchCompetitionInfo("./trending", "trending"),

--- a/project/frontend/src/App.js
+++ b/project/frontend/src/App.js
@@ -7,7 +7,7 @@ import Layout from "./hoc/Layout/Layout";
 import PageRouter from "./hoc/PageRouter/PageRouter";
 
 import { AuthContext } from "./context/AuthContext";
-import { onAuthStateChange } from "./services/firebase";
+import { auth, onAuthStateChange } from "./services/firebase";
 
 export const NO_COMPETITION = 0;
 
@@ -29,7 +29,9 @@ function App() {
   }, []);
 
   useEffect(() => {
-    const parsedCompId = Number(localStorage.getItem("compId") || 0);
+    const parsedCompId = Number(
+      localStorage.getItem("compId") || NO_COMPETITION
+    );
     setCompId(parsedCompId);
   }, []);
 
@@ -49,7 +51,7 @@ function App() {
   const isReadyForDataFetch = () => {
     if (!user.signedIn) return false;
     if (user.id === undefined || user.id === 0) return false;
-    if (compId === 0) return false;
+    if (compId === NO_COMPETITION) return false;
     return true;
   };
 
@@ -97,20 +99,16 @@ function App() {
             innerNav={compId != 0}
             compIdChanged={setCompId}
           />
-          {!authStateReceived ? (
-            <div>Signing in...</div>
-          ) : (
-            <Layout>
-              <PageRouter
-                signedIn={user.signedIn}
-                compId={compId}
-                loading={loading}
-                compIdChanged={setCompId}
-                competitionInfo={competitionInfo}
-                updateCompId={setCompId}
-              />
-            </Layout>
-          )}
+          <Layout>
+            <PageRouter
+              authStateReceived={authStateReceived}
+              signedIn={user.signedIn}
+              compId={compId}
+              loading={loading}
+              competitionInfo={competitionInfo}
+              updateCompId={setCompId}
+            />
+          </Layout>
         </AuthContext>
       </div>
     </BrowserRouter>

--- a/project/frontend/src/App.js
+++ b/project/frontend/src/App.js
@@ -23,7 +23,6 @@ function App() {
       setUser(userData);
       setAuthStateReceived(true);
     });
-
     return () => {
       unsubscribe();
     };
@@ -37,7 +36,6 @@ function App() {
   const fetchCompetitionInfo = async (fetchCall, stateKey) => {
     try {
       const data = await fetch(fetchCall).then((response) => response.json());
-
       return {
         [stateKey]: data,
       };

--- a/project/frontend/src/App.js
+++ b/project/frontend/src/App.js
@@ -48,7 +48,7 @@ function App() {
 
   const isReadyForDataFetch = () => {
     if (!user.signedIn) return false;
-    if (user.id === undefined) return false;
+    if (user.id === undefined || user.id === 0) return false;
     if (compId === 0) return false;
     return true;
   };

--- a/project/frontend/src/App.js
+++ b/project/frontend/src/App.js
@@ -109,62 +109,6 @@ function App() {
     />
   );
 
-  // !user.signedIn ? (
-  //   <Switch>
-  //     <Route path="/signin" component={LandingPage} />
-  //     <Redirect to="/signin" />
-  //   </Switch>
-  // ) : compId == NO_COMPETITION ? (
-  //   <Switch>
-  //     <Route
-  //       path="/compselect"
-  //       render={(props) => (
-  //         <SelectCompetition {...props} compIdChanged={setCompId} />
-  //       )}
-  //     />
-  //     <Redirect to="/compselect" />
-  //   </Switch>
-  // ) : !competitionInfo.generalInfo || loading ? (
-  //   <div>Loading...</div>
-  // ) : (
-  //   <Switch>
-  //     <Route
-  //       path="/dashboard"
-  //       render={() => (
-  //         <Dashboard
-  //           generalInfo={competitionInfo.generalInfo}
-  //           recentBuys={competitionInfo.recentBuys}
-  //           trendingSearches={competitionInfo.trending}
-  //           investments={competitionInfo.investments}
-  //         />
-  //       )}
-  //     />
-  //     <Route path="/competition" render={() => <Competition />} />
-  //     <Route
-  //       path="/mysgonks"
-  //       render={() => (
-  //         <MySGonks
-  //           generalInfo={competitionInfo.generalInfo}
-  //           investments={competitionInfo.investments}
-  //         />
-  //       )}
-  //     />
-  //     <Route
-  //       path="/marketplace"
-  //       render={() => (
-  //         <Marketplace
-  //           generalInfo={competitionInfo.generalInfo}
-  //           recentBuys={competitionInfo.recentBuys}
-  //           trendingSearches={competitionInfo.trending}
-  //           investments={competitionInfo.investments}
-  //         />
-  //       )}
-  //     />
-  //     <Route path="/placeholder" component={Explanation} />
-  //     <Redirect to="/dashboard" />
-  //   </Switch>
-  // );
-
   return (
     <BrowserRouter>
       <div className="App">

--- a/project/frontend/src/App.js
+++ b/project/frontend/src/App.js
@@ -95,21 +95,18 @@ function App() {
 
   let pageRoute = !user.signedIn ? (
     <Switch>
-      <Route path="/signin" component={LandingPage}></Route>
-      <Redirect to="/signin"></Redirect>
+      <Route path="/signin" component={LandingPage} />
+      <Redirect to="/signin" />
     </Switch>
   ) : compId == NO_COMPETITION ? (
     <Switch>
       <Route
         path="/compselect"
         render={(props) => (
-          <SelectCompetition
-            {...props}
-            compIdChanged={setCompId}
-          ></SelectCompetition>
+          <SelectCompetition {...props} compIdChanged={setCompId} />
         )}
-      ></Route>
-      <Redirect to="/compselect"></Redirect>
+      />
+      <Redirect to="/compselect" />
     </Switch>
   ) : !competitionInfo.generalInfo || loading ? (
     <div>Loading...</div>
@@ -123,22 +120,19 @@ function App() {
             recentBuys={competitionInfo.recentBuys}
             trendingSearches={competitionInfo.trending}
             investments={competitionInfo.investments}
-          ></Dashboard>
+          />
         )}
-      ></Route>
-      <Route
-        path="/competition"
-        render={() => <Competition></Competition>}
-      ></Route>
+      />
+      <Route path="/competition" render={() => <Competition />} />
       <Route
         path="/mysgonks"
         render={() => (
           <MySGonks
             generalInfo={competitionInfo.generalInfo}
             investments={competitionInfo.investments}
-          ></MySGonks>
+          />
         )}
-      ></Route>
+      />
       <Route
         path="/marketplace"
         render={() => (
@@ -147,11 +141,11 @@ function App() {
             recentBuys={competitionInfo.recentBuys}
             trendingSearches={competitionInfo.trending}
             investments={competitionInfo.investments}
-          ></Marketplace>
+          />
         )}
-      ></Route>
-      <Route path="/placeholder" component={Explanation}></Route>
-      <Redirect to="/dashboard"></Redirect>
+      />
+      <Route path="/placeholder" component={Explanation} />
+      <Redirect to="/dashboard" />
     </Switch>
   );
 
@@ -163,7 +157,7 @@ function App() {
             loggedIn={user.signedIn}
             innerNav={compId != 0}
             compIdChanged={setCompId}
-          ></HeaderBar>
+          />
           {!authStateReceived ? (
             <div>Signing in...</div>
           ) : (

--- a/project/frontend/src/App.js
+++ b/project/frontend/src/App.js
@@ -15,8 +15,9 @@ import Layout from "./hoc/Layout/Layout";
 import { AuthContext } from "./context/AuthContext";
 import { onAuthStateChange } from "./services/firebase";
 import Marketplace from "./containers/Marketplace/Marketplace";
+import PageRouter from "./hoc/PageRouter/PageRouter";
 
-const NO_COMPETITION = 0;
+export const NO_COMPETITION = 0;
 
 function App() {
   const [user, setUser] = useState({ signedIn: false });
@@ -74,93 +75,103 @@ function App() {
     }
 
     if (isReadyForDataFetch()) {
-      setLoading(true),
-        Promise.all([
-          fetchCompetitionInfo(
-            `./competitionInfo?user=${user.id}&competition=${compId}`,
-            "generalInfo"
-          ),
-          fetchCompetitionInfo(
-            `./recentBuys?competition=${compId}`,
-            "recentBuys"
-          ),
-          fetchCompetitionInfo(
-            `./investments?user=${user.id}&competition=${compId}`,
-            "investments"
-          ),
-          fetchCompetitionInfo("./trending", "trending"),
-        ]).then((resolvedData) => {
-          setLoading(false);
-          console.log(resolvedData);
-          console.log(competitionInfo);
-          let newCompInfo = {};
-          for (const response of resolvedData) {
-            newCompInfo = {
-              ...newCompInfo,
-              ...response,
-            };
-          }
-
-          setCompetitionInfo(newCompInfo);
-        });
+      setLoading(true);
+      Promise.all([
+        fetchCompetitionInfo(
+          `./competitionInfo?user=${user.id}&competition=${compId}`,
+          "generalInfo"
+        ),
+        fetchCompetitionInfo(
+          `./recentBuys?competition=${compId}`,
+          "recentBuys"
+        ),
+        fetchCompetitionInfo(
+          `./investments?user=${user.id}&competition=${compId}`,
+          "investments"
+        ),
+        fetchCompetitionInfo("./trending", "trending"),
+      ]).then((resolvedData) => {
+        setLoading(false);
+        console.log(resolvedData);
+        console.log(competitionInfo);
+        let newCompInfo = {};
+        for (const response of resolvedData) {
+          newCompInfo = {
+            ...newCompInfo,
+            ...response,
+          };
+        }
+        setCompetitionInfo(newCompInfo);
+      });
     }
   }, [user.id, authStateReceived]);
 
-  let pageRoute = !user.signedIn ? (
-    <Switch>
-      <Route path="/signin" component={LandingPage} />
-      <Redirect to="/signin" />
-    </Switch>
-  ) : compId == NO_COMPETITION ? (
-    <Switch>
-      <Route
-        path="/compselect"
-        render={(props) => (
-          <SelectCompetition {...props} compIdChanged={setCompId} />
-        )}
-      />
-      <Redirect to="/compselect" />
-    </Switch>
-  ) : !competitionInfo.generalInfo || loading ? (
-    <div>Loading...</div>
-  ) : (
-    <Switch>
-      <Route
-        path="/dashboard"
-        render={() => (
-          <Dashboard
-            generalInfo={competitionInfo.generalInfo}
-            recentBuys={competitionInfo.recentBuys}
-            trendingSearches={competitionInfo.trending}
-            investments={competitionInfo.investments}
-          />
-        )}
-      />
-      <Route path="/competition" render={() => <Competition />} />
-      <Route
-        path="/mysgonks"
-        render={() => (
-          <MySGonks
-            generalInfo={competitionInfo.generalInfo}
-            investments={competitionInfo.investments}
-          />
-        )}
-      />
-      <Route
-        path="/marketplace"
-        render={() => (
-          <Marketplace
-            generalInfo={competitionInfo.generalInfo}
-            recentBuys={competitionInfo.recentBuys}
-            trendingSearches={competitionInfo.trending}
-            investments={competitionInfo.investments}
-          />
-        )}
-      />
-      <Route path="/placeholder" component={Explanation} />
-      <Redirect to="/dashboard" />
-    </Switch>
+  let pageRoute = (
+    <PageRouter
+      signedIn={user.signedIn}
+      compId={compId}
+      loading={loading}
+      compIdChanged={setCompId}
+      competitionInfo={competitionInfo}
+      updateCompId={setCompId}
+    />
   );
+
+  // !user.signedIn ? (
+  //   <Switch>
+  //     <Route path="/signin" component={LandingPage} />
+  //     <Redirect to="/signin" />
+  //   </Switch>
+  // ) : compId == NO_COMPETITION ? (
+  //   <Switch>
+  //     <Route
+  //       path="/compselect"
+  //       render={(props) => (
+  //         <SelectCompetition {...props} compIdChanged={setCompId} />
+  //       )}
+  //     />
+  //     <Redirect to="/compselect" />
+  //   </Switch>
+  // ) : !competitionInfo.generalInfo || loading ? (
+  //   <div>Loading...</div>
+  // ) : (
+  //   <Switch>
+  //     <Route
+  //       path="/dashboard"
+  //       render={() => (
+  //         <Dashboard
+  //           generalInfo={competitionInfo.generalInfo}
+  //           recentBuys={competitionInfo.recentBuys}
+  //           trendingSearches={competitionInfo.trending}
+  //           investments={competitionInfo.investments}
+  //         />
+  //       )}
+  //     />
+  //     <Route path="/competition" render={() => <Competition />} />
+  //     <Route
+  //       path="/mysgonks"
+  //       render={() => (
+  //         <MySGonks
+  //           generalInfo={competitionInfo.generalInfo}
+  //           investments={competitionInfo.investments}
+  //         />
+  //       )}
+  //     />
+  //     <Route
+  //       path="/marketplace"
+  //       render={() => (
+  //         <Marketplace
+  //           generalInfo={competitionInfo.generalInfo}
+  //           recentBuys={competitionInfo.recentBuys}
+  //           trendingSearches={competitionInfo.trending}
+  //           investments={competitionInfo.investments}
+  //         />
+  //       )}
+  //     />
+  //     <Route path="/placeholder" component={Explanation} />
+  //     <Redirect to="/dashboard" />
+  //   </Switch>
+  // );
 
   return (
     <BrowserRouter>

--- a/project/frontend/src/App.js
+++ b/project/frontend/src/App.js
@@ -136,84 +136,6 @@ function App() {
           <MySGonks
             generalInfo={competitionInfo.generalInfo}
             investments={competitionInfo.investments}
-            //Since real back end data currently has no data that could be displayed
-            //Please comment out the comment above and UNcomment the block below to see an example of the sgonks display
-            /*
-            investments={[
-              {
-                amtInvested: 400,
-                currentValue: 0,
-                dataPoints: [162, 152, 150, 158, 1087],
-                dateInvestedMilliSeconds: 1611705600000,
-                dateSoldMilliSeconds: 1611792000000,
-                searchItem: "feadas",
-              },
-              {
-                amtInvested: 321,
-                currentValue: 421,
-                dataPoints: [162, 152, 150, 1528, 11],
-                dateInvestedMilliSeconds: 1611705600000,
-                dateSoldMilliSeconds: 0,
-                searchItem: "france",
-              },
-              {
-                amtInvested: 111,
-                currentValue: 222,
-                dataPoints: [162, 152, 150, 12, 13],
-                dateInvestedMilliSeconds: 1611705600000,
-                dateSoldMilliSeconds: 1611792000000,
-                searchItem: "gfsdgfs",
-              },
-              {
-                amtInvested: 321,
-                currentValue: 421,
-                dataPoints: [162, 152, 150, 158, 1087],
-                dateInvestedMilliSeconds: 1611705600000,
-                dateSoldMilliSeconds: 0,
-                searchItem: "dddddd",
-              },
-              {
-                amtInvested: 1,
-                currentValue: 8,
-                dataPoints: [162, 152, 150, 1321, 13213],
-                dateInvestedMilliSeconds: 1611705600000,
-                dateSoldMilliSeconds: 0,
-                searchItem: "ccccccc",
-              },
-              {
-                amtInvested: 1,
-                currentValue: 8,
-                dataPoints: [162, 152, 150, 1321, 13213],
-                dateInvestedMilliSeconds: 1611705600000,
-                dateSoldMilliSeconds: 0,
-                searchItem: "bbbbbbbb",
-              },
-              {
-                amtInvested: 1,
-                currentValue: 8,
-                dataPoints: [162, 152, 150, 1321, 13213],
-                dateInvestedMilliSeconds: 1611705600000,
-                dateSoldMilliSeconds: 0,
-                searchItem: "aaaaaaaa",
-              },
-              {
-                amtInvested: 13,
-                currentValue: 82,
-                dataPoints: [162, 152, 150, 1321, 13213],
-                dateInvestedMilliSeconds: 1611705600000,
-                dateSoldMilliSeconds: 0,
-                searchItem: "zzzzzz",
-              },
-              {
-                amtInvested: 213,
-                currentValue: 321,
-                dataPoints: [162, 152, 150, 1321, 13213],
-                dateInvestedMilliSeconds: 1611705600000,
-                dateSoldMilliSeconds: 0,
-                searchItem: "fadfsdafsdfdas",
-              },
-            ]}
-            */
           ></MySGonks>
         )}
       ></Route>
@@ -229,7 +151,7 @@ function App() {
         )}
       ></Route>
       <Route path="/placeholder" component={Explanation}></Route>
-      <Redirect to="/competition"></Redirect>
+      <Redirect to="/dashboard"></Redirect>
     </Switch>
   );
 

--- a/project/frontend/src/App.js
+++ b/project/frontend/src/App.js
@@ -96,7 +96,7 @@ function App() {
         <AuthContext>
           <HeaderBar
             loggedIn={user.signedIn}
-            innerNav={compId != 0}
+            innerNav={compId != NO_COMPETITION}
             compIdChanged={setCompId}
           />
           <Layout>

--- a/project/frontend/src/App.js
+++ b/project/frontend/src/App.js
@@ -55,12 +55,25 @@ function App() {
     }
   };
 
+  const isReadyForDataFetch = () => {
+    if (!user.signedIn) {
+      return false;
+    }
+    if (user.id === undefined) {
+      return false;
+    }
+    if (compId === 0) {
+      return false;
+    }
+    return true;
+  };
+
   useEffect(() => {
     if (!authStateReceived) {
       return;
     }
 
-    if (user.signedIn && user.id && compId) {
+    if (isReadyForDataFetch()) {
       setLoading(true),
         Promise.all([
           fetchCompetitionInfo(

--- a/project/frontend/src/components/HeaderBar/HeaderBar.js
+++ b/project/frontend/src/components/HeaderBar/HeaderBar.js
@@ -8,9 +8,9 @@ import Aux from "../../hoc/Auxiliary";
 
 const HeaderBar = (props) => {
   let innerNavLinks = [
-    { linkTo: "/", display: "My sGonks", key: "mysgonks" },
-    { linkTo: "/", display: "Competition", key: "competition" },
-    { linkTo: "/", display: "Marketplace", key: "marketplace" },
+    { linkTo: "/mysgonks", display: "My sGonks", key: "mysgonks" },
+    { linkTo: "/competition", display: "Competition", key: "competition" },
+    { linkTo: "/marketplace", display: "Marketplace", key: "marketplace" },
   ];
 
   let innerNav = props.innerNav ? (

--- a/project/frontend/src/components/SGonksLists/LongSGonksList/LongSGonksList.js
+++ b/project/frontend/src/components/SGonksLists/LongSGonksList/LongSGonksList.js
@@ -3,18 +3,22 @@ import classes from "./LongSGonksList.module.css";
 import LongSGonkRow from "./LongSGonkRow/LongSGonkRow";
 
 const LongSGonksList = (props) => {
-  const investmentRows = props.investments.map((investment, i) => {
-    return (
-      <LongSGonkRow
-        //TODO replace key with investment id once it's ready
-        key={i}
-        searchTerm={investment.searchItem}
-        buyInDate={investment.dateInvestedMilliSeconds}
-        amountInvested={investment.amtInvested}
-        currentValue={investment.currentValue}
-      ></LongSGonkRow>
-    );
-  });
+  const investmentRows = !props.investments ? (
+    <div>undefined</div>
+  ) : (
+    props.investments.map((investment, i) => {
+      return (
+        <LongSGonkRow
+          //TODO replace key with investment id once it's ready
+          key={i}
+          searchTerm={investment.searchItem}
+          buyInDate={investment.dateInvestedMilliSeconds}
+          amountInvested={investment.amtInvested}
+          currentValue={investment.currentValue}
+        ></LongSGonkRow>
+      );
+    })
+  );
   return (
     <div className={classes.ListWrapper}>
       <div className={classes.TitleRow}>

--- a/project/frontend/src/components/SGonksLists/LongSGonksList/LongSGonksList.js
+++ b/project/frontend/src/components/SGonksLists/LongSGonksList/LongSGonksList.js
@@ -3,6 +3,7 @@ import classes from "./LongSGonksList.module.css";
 import LongSGonkRow from "./LongSGonkRow/LongSGonkRow";
 
 const LongSGonksList = (props) => {
+  //TODO: Change this ternary to something more readable
   const investmentRows = !props.investments ? (
     <div>undefined</div>
   ) : (

--- a/project/frontend/src/containers/Marketplace/Marketplace.js
+++ b/project/frontend/src/containers/Marketplace/Marketplace.js
@@ -6,7 +6,6 @@ import RecentBuys from "../../components/RecentBuys/RecentBuysList";
 import Button from "../../components/UI/Button/Button";
 
 const Marketplace = (props) => {
-  console.log(props);
   return (
     <div className={classes.MarketplaceContainer}>
       <div className={classes.BuyContainer}>

--- a/project/frontend/src/containers/MySGonks/MySGonks.js
+++ b/project/frontend/src/containers/MySGonks/MySGonks.js
@@ -5,9 +5,11 @@ import LinkButton from "../../components/UI/LinkButton/LinkButton";
 import LongSGonksList from "../../components/SGonksLists/LongSGonksList/LongSGonksList";
 
 const MySGonks = (props) => {
-  const unsoldInvestments = props.investments.filter(
-    (investment) => investment.dateSoldMilliSeconds == 0
-  );
+  const unsoldInvestments = !props.investments
+    ? undefined
+    : props.investments.filter(
+        (investment) => investment.dateSoldMilliSeconds == 0
+      );
 
   return (
     <div className={classes.MySGonksContainer}>

--- a/project/frontend/src/hoc/PageRouter/PageRouter.js
+++ b/project/frontend/src/hoc/PageRouter/PageRouter.js
@@ -1,0 +1,81 @@
+import React from "react";
+import { Route, Switch, Redirect } from "react-router-dom";
+
+import LandingPage from "../../containers/LandingPage/LandingPage";
+import SelectCompetition from "../../containers/SelectCompetition/SelectCompetition";
+import Dashboard from "../../containers/Dashboard/Dashboard";
+import MySGonks from "../../containers/MySGonks/MySGonks";
+import Marketplace from "../../containers/Marketplace/Marketplace";
+import Competition from "../../containers/Competition/Competition";
+
+import { NO_COMPETITION } from "../../App";
+
+const PageRouter = (props) => {
+  console.log(props);
+  if (!props.signedIn) {
+    return (
+      <Switch>
+        <Route path="/signin" component={LandingPage} />
+        <Redirect to="/signin" />
+      </Switch>
+    );
+  }
+
+  if (props.compId === NO_COMPETITION) {
+    return (
+      <Switch>
+        <Route
+          path="/compselect"
+          render={(props) => (
+            <SelectCompetition {...props} compIdChanged={setCompId} />
+          )}
+        />
+        <Redirect to="/compselect" />
+      </Switch>
+    );
+  }
+
+  if (props.loading || Object.keys(props.competitionInfo).length === 0) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <Switch>
+      <Route
+        path="/dashboard"
+        render={() => (
+          <Dashboard
+            generalInfo={props.competitionInfo.generalInfo}
+            recentBuys={props.competitionInfo.recentBuys}
+            trendingSearches={props.competitionInfo.trending}
+            investments={props.competitionInfo.investments}
+          />
+        )}
+      />
+      <Route path="/competition" render={() => <Competition />} />
+      <Route
+        path="/mysgonks"
+        render={() => (
+          <MySGonks
+            generalInfo={props.competitionInfo.generalInfo}
+            investments={props.competitionInfo.investments}
+          />
+        )}
+      />
+      <Route
+        path="/marketplace"
+        render={() => (
+          <Marketplace
+            generalInfo={props.competitionInfo.generalInfo}
+            recentBuys={props.competitionInfo.recentBuys}
+            trendingSearches={props.competitionInfo.trending}
+            investments={props.competitionInfo.investments}
+          />
+        )}
+      />
+      <Redirect to="/dashboard" />
+    </Switch>
+  );
+};
+
+export default PageRouter;

--- a/project/frontend/src/hoc/PageRouter/PageRouter.js
+++ b/project/frontend/src/hoc/PageRouter/PageRouter.js
@@ -12,6 +12,10 @@ import { NO_COMPETITION } from "../../App";
 
 const PageRouter = (props) => {
   console.log(props);
+
+  if (!props.authStateReceived) {
+    return <div>Signing in...</div>;
+  }
   if (!props.signedIn) {
     return (
       <Switch>
@@ -27,7 +31,7 @@ const PageRouter = (props) => {
         <Route
           path="/compselect"
           render={(props) => (
-            <SelectCompetition {...props} compIdChanged={setCompId} />
+            <SelectCompetition {...props} compIdChanged={props.updateCompId} />
           )}
         />
         <Redirect to="/compselect" />

--- a/project/frontend/src/services/firebase.js
+++ b/project/frontend/src/services/firebase.js
@@ -35,6 +35,7 @@ export const onAuthStateChange = (callback) => {
         signedIn: true,
         name: user.displayName,
         email: user.email,
+        id: 1,
       });
     } else {
       callback({


### PR DESCRIPTION
* There was a problem where routing wasn't working together with auth flow. This is because many things were kinda wonky. I will try to explain this to the best of my ability... 
   * Inner routing was completely broken: there was no way to route between pages once you're logged in, and you can't go to any page other than the default redirect page by changing the url.. This was because:
   * In App.js the user's auth state is checked inside a useEffect
   * Data is fetched in a useEffect 
   * The page route is defined inside a let pageRoute... this is not inside useEffect
   * The page route ternary statement executes before the auth state check - and by default, the user is NOT signed in (until we check and find out that the user is signed in). So the ternary statement sees that the user is not signed in, and redirects the user to /signin no matter what the old url was. Then in a while, the app detects that the user is signed in, and then the ternary statement executes again - but now the url is /signin which is not any of the signed in routes defined, hence it then redirects to whatever is in Redirect
   * To solve this problem, an authStateReceived state is made, this prevents the ternary statement from trying to load data and load routes before auth is successful. It checks that if authStateReceived is false, App.js shortcircuits and returns (nothing) before the routes could be defined. In the JSX body, we check if it is false, and if it's false, we show "signing in". 
   *  The useEffect which loads all the data and changes the loading state (of the data) now has authStateReceived as a dependency, so that when it changes, it reruns. 
       * setLoading(true) has now been pulled out of the promise.all because that's baaad (because thigns in Promise.all execute simultaneously, and we want setLoading to be true before any of the fetches even start executing. Before we were simply lucky that things work because setLoading happens to be the function that finishes the fastest. 
       *  FetchAndUpdateCompetitionInfo function now doesn't directly update the state as soon as it receives data, because that is bad practice for what we want to do. Instead this has now been refactored to be fetchCompetitionInfo and it doesn't just update the state and instead it returns an object that needs to be inserted into the state in a stateKey: value pair. After promise.all finishes executing this will return an array of the results of the promises, which we have named resolvedData. We then extract these objects from the array and set it to be a variable newCompInfo, we then set the state competitionInfo to be the newCompInfo.
     * When authStateDefined exists, short circuiting will not happen and routes will be defined - so now we add another check to see if competitionInfo has content on top of loading, to see if we are ready to load inner page content yet
* There is currently a makeshift thing going on which will be expanded in the next PR, where even if investments is not fetched (gets undefined), the app doesn't break, instead it just (currently) shows the sgonks list as "undefined". This feature will be expanded in a coming PR to make this prettier and more user friendly (aka not just an ugly "undefined") and also extend this logic to other sections (for if/when they fail to get fetched)
* Fetching user's id after auth is no longer done in App, it is done within the auth itself (id still hardcoded)

_**There is a lot of stuff in here, and I might have missed some stuff, please talk to me if you need further explanation on anything**_ 

# TLDR : a lot of bad things before, and as a result inner routing didn't work. inner routing works now and as a bonus the app doesn't break if investment doesn't exist

