### PR TITLE
Update python scripts to work around case where Google Trends returns incomplete data

### DIFF
--- a/project/scripts/data_generator.py
+++ b/project/scripts/data_generator.py
@@ -1,0 +1,72 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#!/usr/bin/env python3
+
+import math
+from random import gauss
+from scipy import special
+
+from dates import get_previous_day, get_next_day
+
+
+def get_missing_data_point(required_dates, daily_data, date):
+    """
+    Calculate a suitable data point with relevant probability from known info
+    """
+    if get_previous_day(date) in daily_data and get_next_day(date) in daily_data:
+        # if we have neighbouring data points, generate point with gaussian smoothing
+        return get_smoothed_value(get_previous_day(date), get_next_day(date))
+    else:
+        # if we have no neighbouring data, take a probabilistic guess
+        return get_gaussian_random(len(required_dates))
+
+
+def get_gaussian_random(time_range):
+    """
+    Return a random value for the data point between 0 and 100, over a gaussian distribution
+    determined by the range of data required
+    """
+    # The actual data will be 100 and 0 once each over the respective time range
+    # so over a larger time range, the probability of this specific entry being high or low
+    # decreases. We adjust the standard deviation accordingly to generate reasonable values.
+    lower = 0
+    upper = 100
+    mean = 50
+    chance_of_extremity = 1 / time_range
+    f = 1 - chance_of_extremity
+    num_standard_devs = special.erfinv(f) * math.sqrt(2)
+    standard_dev = 50 / num_standard_devs
+    value = gauss(mean, standard_dev)
+
+    while value < lower or value > upper:
+        #check if value outside range. This will basically never happen
+        value = gauss(mean, standard_dev)
+    return round(value)
+
+
+def get_smoothed_value(prev, next):
+    """
+    Given the data points for the next and previous days, generate the data point
+    using modified Gaussian smoothing
+    """
+    # unsophisticated average of neighbouring 2 points
+    straight_average = (prev + next) / 2
+
+    # add some noise with gaussian distribution centered on this point
+    mean = straight_average
+    std_dev = abs(straight_average - next) / 5
+    value = gauss(mean, std_dev) # less than 0.1% chance of not falling between next and prev
+    return round(value)

--- a/project/scripts/data_generator.py
+++ b/project/scripts/data_generator.py
@@ -22,7 +22,7 @@ from scipy import special
 from dates import get_previous_day, get_next_day
 
 
-def get_missing_data_point(required_dates, daily_data, date):
+def backfill_missing_data_as_necessary(required_dates, daily_data, date):
     """
     Calculate a suitable data point with relevant probability from known info
     """

--- a/project/scripts/data_generator.py
+++ b/project/scripts/data_generator.py
@@ -22,7 +22,7 @@ from scipy import special
 from dates import get_previous_day, get_next_day
 
 
-def backfill_missing_data_as_necessary(required_dates, daily_data, date):
+def get_missing_data_point(required_dates, daily_data, date):
     """
     Calculate a suitable data point with relevant probability from known info
     """

--- a/project/scripts/database_updates.py
+++ b/project/scripts/database_updates.py
@@ -22,17 +22,11 @@ from google.cloud import datastore
 def get_investment_data(client):
     """
     Fetch investment data from database.
-    returns a list of ("search_term", "investment_date") tuples
+    returns a list of datastore entities.
     """
-    search_terms = []
-    investment_dates = []
-
     query = client.query(kind="TrendsData")
-    results = list(query.fetch()) # a list of every entry of kind TrendsData
-    for entity in results:
-        search_terms.append(entity['search_term'])
-        investment_dates.append(entity['initial_date'])
-    return zip(search_terms, investment_dates)
+    entities = list(query.fetch()) # a list of every entry of kind TrendsData
+    return entities
 
 
 def update_investment_database(data, client):

--- a/project/scripts/dates.py
+++ b/project/scripts/dates.py
@@ -6,6 +6,7 @@
 from datetime import datetime, timezone, timedelta
 import pytz
 
+SECONDS_ONE_DAY = 24 * 60 * 60
 
 def get_start_times(date):
     """
@@ -41,3 +42,31 @@ def date_to_epoch(date):
     utc_time = dt.replace(tzinfo = timezone.utc) 
     utc_dt = utc_time.timestamp()
     return int(utc_dt)
+
+
+def get_all_dates(initial_date):
+    """
+    Given the initial date, return a list of all dates between then
+    and now in epoch form, midnight UTC time
+    """
+    end_date = date_to_epoch(get_current_date())
+    date = initial_date
+    dates = []
+    while date <= end_date:
+        dates.append(date)
+        date += SECONDS_ONE_DAY
+    return dates
+
+
+def get_previous_day(date):
+    """
+    given a date epoch, return the previous day epoch
+    """
+    return date - SECONDS_ONE_DAY
+
+
+def get_next_day(date):
+    """
+    given a date epoch, return the next day epoch
+    """
+    return date + SECONDS_ONE_DAY

--- a/project/scripts/fetch_trends.py
+++ b/project/scripts/fetch_trends.py
@@ -22,15 +22,14 @@ from pytrends.request import TrendReq
 pytrends = TrendReq(tz=0) #tz=0 puts us on UTC
 
 from dates import get_start_times, get_end_times, date_to_epoch, get_all_dates
-from data_generator import backfill_missing_data_as_necessary
+from data_generator import get_missing_data_point
 
 NUM_TRENDING = 10 # number of trending searches to return
 
 
 def get_updated_daily_data(entity):
     """
-    search_term: a search to retrieve data for
-    investment_date: the date to start fetching data from as an int since epoch
+    entity : the datastore entity for this investment
     returns a pandas dataframe of daily data for the query from the investment date to today
     """
     investment_date = entity['initial_date']
@@ -95,7 +94,7 @@ def aggregate_hourly_to_daily(hourly_df):
     return new_data
 
 
-def verify_data_complete(daily_data, entity):
+def backfill_missing_data_as_necessary(daily_data, entity):
     """
     Verify that we have a complete data set for the required dates. If not, fill in the blanks
     with old potentially outdated data or worst case scenario, random data

--- a/project/scripts/fetch_trends.py
+++ b/project/scripts/fetch_trends.py
@@ -22,7 +22,7 @@ from pytrends.request import TrendReq
 pytrends = TrendReq(tz=0) #tz=0 puts us on UTC
 
 from dates import get_start_times, get_end_times, date_to_epoch, get_all_dates
-from data_generator import get_missing_data_point
+from data_generator import backfill_missing_data_as_necessary
 
 NUM_TRENDING = 10 # number of trending searches to return
 
@@ -40,9 +40,9 @@ def get_updated_daily_data(entity):
 
     hourly_data = fetch_hourly_data(search_term, *start, *end)
     daily_data = aggregate_hourly_to_daily(hourly_data)
-    verified_data = verify_data_complete(daily_data, entity)
+    complete_data = backfill_missing_data_as_necessary(daily_data, entity)
 
-    return verified_data
+    return complete_data
 
 
 def fetch_hourly_data(search_term, year_start, month_start, day_start, year_end, month_end, day_end):

--- a/project/scripts/fetch_trends.py
+++ b/project/scripts/fetch_trends.py
@@ -18,26 +18,31 @@
 
 import pandas as pd
 from pytrends.request import TrendReq
+
 pytrends = TrendReq(tz=0) #tz=0 puts us on UTC
 
-from dates import get_start_times, get_end_times, date_to_epoch
+from dates import get_start_times, get_end_times, date_to_epoch, get_all_dates
+from data_generator import get_missing_data_point
 
 NUM_TRENDING = 10 # number of trending searches to return
 
 
-def get_updated_daily_data(search_term, investment_date):
+def get_updated_daily_data(entity):
     """
     search_term: a search to retrieve data for
     investment_date: the date to start fetching data from as an int since epoch
     returns a pandas dataframe of daily data for the query from the investment date to today
     """
+    investment_date = 1611360000
+    search_term = entity['search_term']
     start = get_start_times(investment_date)
     end = get_end_times()
 
     hourly_data = fetch_hourly_data(search_term, *start, *end)
     daily_data = aggregate_hourly_to_daily(hourly_data)
+    verified_data = verify_data_complete(daily_data, entity)
 
-    return daily_data
+    return verified_data
 
 
 def fetch_hourly_data(search_term, year_start, month_start, day_start, year_end, month_end, day_end):
@@ -71,9 +76,7 @@ def aggregate_hourly_to_daily(hourly_df):
     """
     search_term = hourly_df.columns[0]
     new_data = {
-        "search_term": search_term,
-        "initial_date": date_to_epoch(hourly_df.index[0]),
-        "latest_date": date_to_epoch(hourly_df.index[-1])
+        "search_term": search_term
     }
     count = 0
     day_total = 0
@@ -90,6 +93,32 @@ def aggregate_hourly_to_daily(hourly_df):
             count = 0
 
     return new_data
+
+
+def verify_data_complete(daily_data, entity):
+    """
+    Verify that we have a complete data set for the required dates. If not, fill in the blanks
+    with old potentially outdated data or worst case scenario, random data
+    """
+    required_dates = get_all_dates(1611360000)
+    for date in required_dates:
+        # convert date to string for datastore indexing purposes
+        date_str = str(date)
+        if date_str in daily_data:
+            # we have successfully retrieved data for this date
+            continue
+        elif hasattr(entity, date_str):
+            # we have old data in the database. default to this
+            daily_data[date_str] = entity[date_str]
+        else:
+            # we have no data anywhere for this date. This *shouldn't* happen often.
+            val = get_missing_data_point(required_dates, daily_data, date)
+            daily_data[date_str] = val
+
+    daily_data['initial_date'] = 1611360000
+    daily_data['latest_date'] = str(required_dates[-1])
+
+    return daily_data
 
 
 def get_trending_searches():

--- a/project/scripts/fetch_trends.py
+++ b/project/scripts/fetch_trends.py
@@ -33,7 +33,7 @@ def get_updated_daily_data(entity):
     investment_date: the date to start fetching data from as an int since epoch
     returns a pandas dataframe of daily data for the query from the investment date to today
     """
-    investment_date = 1611360000
+    investment_date = entity['initial_date']
     search_term = entity['search_term']
     start = get_start_times(investment_date)
     end = get_end_times()
@@ -100,7 +100,7 @@ def verify_data_complete(daily_data, entity):
     Verify that we have a complete data set for the required dates. If not, fill in the blanks
     with old potentially outdated data or worst case scenario, random data
     """
-    required_dates = get_all_dates(1611360000)
+    required_dates = get_all_dates(entity['initial_date'])
     for date in required_dates:
         # convert date to string for datastore indexing purposes
         date_str = str(date)
@@ -115,8 +115,8 @@ def verify_data_complete(daily_data, entity):
             val = get_missing_data_point(required_dates, daily_data, date)
             daily_data[date_str] = val
 
-    daily_data['initial_date'] = 1611360000
-    daily_data['latest_date'] = str(required_dates[-1])
+    daily_data['initial_date'] = entity['initial_date']
+    daily_data['latest_date'] = required_dates[-1]
 
     return daily_data
 

--- a/project/scripts/main.py
+++ b/project/scripts/main.py
@@ -37,10 +37,10 @@ if __name__ == "__main__":
     # Instantiates a client
     datastore_client = datastore.Client()
     # Retrieve relevant data from datastore
-    investments = get_investment_data(datastore_client)
-    for investment in investments:
+    entities = get_investment_data(datastore_client)
+    for entity in entities:
         # Retrieve up to date trends data for each search term
-        daily_data = get_updated_daily_data(*investment)
+        daily_data = get_updated_daily_data(entity)
         # Add up to date data do datastore
         update_investment_database(daily_data, datastore_client)
 


### PR DESCRIPTION
New code first checks if trends has returned data for every single required date. If so nothing different happens. Otherwise:

 - if the entity we queried from the database has old data for the date with missing data, we use that as a next best guess at the value of the datapoint.
 - if for some reason we don't have old data either, we generate new data in one of two ways: 
 - - If we have neighbouring datapoints for the missing data, we use a modified gaussian smoothing function to estimate a midway point for the missing data
 - - If we don't have neighbouring datapoints, we generate a gaussian distribution using the probability of the point being an extremity to determine standard deviation, and choose the value of the point randomly from this.


Modified files:
 - dates.py has a few new functions used for checking the completeness of the data
 - data_generator.py has functions for producing missing data
 - database_updates.py has has the data retrieval function modified to return an entity instead of a tuple. This enables lookup of old data if necessary
 - fetch_trends.py has been modified to check completeness of PyTrends returned data and fill missing data in if required.
 - main.py has been modified to work with entities returned from database_updates.py instead of tuples

resolves #124 