### PR TITLE
Fix date bug, net worth history update no longer broken

### DIFF
--- a/project/src/main/java/com/google/sps/servlets/InvestmentCalculator.java
+++ b/project/src/main/java/com/google/sps/servlets/InvestmentCalculator.java
@@ -79,7 +79,7 @@ public class InvestmentCalculator {
             int amtInvested;
             while (rs.next()) {
                 googleSearch = rs.getString(1);
-                investDate = rs.getDate(2).getTime();
+                investDate = convertDateToEpochLong(rs.getDate(2));
                 sellDateOrNull = rs.getDate(3);
                 if (sellDateOrNull == null) {
                     sellDate = 0;


### PR DESCRIPTION
There was one final SQL date conversion bug remaining in the investment calculator, that was preventing the net worth update from running correctly. This has been fixed.

Resolves #127 