### PR TITLE
Add investment id to investment object, intialise networth in datastore on competition creation

### DIFF
--- a/project/src/main/java/com/google/sps/data/Investment.java
+++ b/project/src/main/java/com/google/sps/data/Investment.java
@@ -22,9 +22,11 @@ import com.google.common.collect.ImmutableList;
 @AutoValue
 public abstract class Investment {
   public static Investment create(
-    String searchItem, long dateInvestedMilliSeconds, long dateSoldMilliSeconds, int amtInvested, int currentValue, ImmutableList<Long> dataPoints) {
-    return new AutoValue_Investment(searchItem, dateInvestedMilliSeconds, dateSoldMilliSeconds, amtInvested, currentValue, dataPoints);
+    Long id, String searchItem, long dateInvestedMilliSeconds, long dateSoldMilliSeconds, int amtInvested, int currentValue, ImmutableList<Long> dataPoints) {
+    return new AutoValue_Investment(id, searchItem, dateInvestedMilliSeconds, dateSoldMilliSeconds, amtInvested, currentValue, dataPoints);
   }
+  /** The id of the investment in investments table */
+  public abstract long id();
   /** The search query that is invested */
   public abstract String searchItem();
   /** The date that this investment is made stored in a millisecond type*/

--- a/project/src/main/java/com/google/sps/servlets/CompetitionsServlet.java
+++ b/project/src/main/java/com/google/sps/servlets/CompetitionsServlet.java
@@ -276,8 +276,8 @@ public class CompetitionsServlet extends HttpServlet {
     Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
     InvestmentCalculator calc = new InvestmentCalculator();
 
-    /** This might be before the comp starts but that's not a problem, the UI will just show
-      constant net worths until after the start date */
+    /** This might be a bit before the comp starts but that's not a problem as we only query 
+     * the dates we want anyway. */
     String currentDate = Long.toString(calc.getLatestDate());
     String entityId = String.format("id=%dcompetition=%d", user, competition);
 


### PR DESCRIPTION
 - Fix investment object definition to include the id of the investment in the investments table
 - Edit the investment instantiation in the investment servlet to include this id

This is done so that frontend can later on query using the investment id for selling etc

 - Move initial networth to be a global constant in the competition servlet
 - Add each competitor along with their initial networth to the networth history db in datastore when a competition is created

Resolves #133, resolves #134