### PR TITLE
Fix two small bugs in the Python data faking script

### DIFF
--- a/project/scripts/data_generator.py
+++ b/project/scripts/data_generator.py
@@ -43,9 +43,9 @@ def get_gaussian_random(time_range):
     # so over a larger time range, the probability of this specific entry being high or low
     # decreases. We adjust the standard deviation accordingly to generate reasonable values.
     lower = 0
-    upper = 2400
-    mean = 1200
-    chance_of_extremity = (1 / (time_range * 24)) ** 24
+    upper = 100
+    mean = 50
+    chance_of_extremity = 1 / time_range
     f = 1 - chance_of_extremity
     num_standard_devs = special.erfinv(f) * math.sqrt(2)
     standard_dev = (upper - mean) / num_standard_devs
@@ -54,7 +54,7 @@ def get_gaussian_random(time_range):
     while value < lower or value > upper:
         #check if value outside range. This will basically never happen
         value = gauss(mean, standard_dev)
-    return round(value)
+    return 24 * round(value)
 
 
 def get_smoothed_value(prev, next):

--- a/project/scripts/fetch_trends.py
+++ b/project/scripts/fetch_trends.py
@@ -103,7 +103,10 @@ def backfill_missing_data_as_necessary(daily_data, entity):
     for date in required_dates:
         # convert date to string for datastore indexing purposes
         date_str = str(date)
-        if date_str in daily_data:
+        # NOTE : Pytrends fails in one of two ways: Mostly it returns blank data, in which case the date_str
+        # will not be present in the dataframe. But sometimes it returns a stream of 0s. Since it is near impossible
+        # to get 24 0 points in a row for legitimate reasons, we here treat any daily datapoint of 0 as missing data.
+        if date_str in daily_data and daily_data[date_str] != 0:
             # we have successfully retrieved data for this date
             continue
         elif hasattr(entity, date_str):


### PR DESCRIPTION
 - the previous attempt at modifying the Gaussian distribution to model 24 hours worth of data resulted in a floating point error from a very small probability. This has been amended by accounting for the number of data points at the end rather than the start.
 -  the previous backfill missing data function only checked for absent data. Sometimes Pytrends returns a clump of datapoints that are all 0, which is statistically near impossible to be real data. I have modified the script to treat any day that consisted of entirely 0 datapoints for 24 hours as a missing point rather than valid data.

I will update the Cloud Function scripts to match when approved.