### PR TITLE
Fix date added to db on sell

### DIFF
--- a/project/src/main/java/com/google/sps/servlets/SellServlet.java
+++ b/project/src/main/java/com/google/sps/servlets/SellServlet.java
@@ -77,10 +77,12 @@ public class SellServlet extends HttpServlet {
       }
 
       //add today as the sell date to the investment
-      Date today = new Date();
+      InvestmentCalculator calc = new InvestmentCalculator();
+      Long currentDateSeconds = calc.getLatestDate();
+      Date currentDate = new Date(currentDateSeconds * 1000);
       String updateSellDateStmt = String.format(
           "UPDATE investments SET sell_date=DATE '%tF' WHERE id=%d;",
-          today, investmentID);
+          currentDate, investmentID);
       try (PreparedStatement statement = conn.prepareStatement(updateSellDateStmt)) {
         statement.execute();
       }


### PR DESCRIPTION
 - Previous sell servlet was adding today's date as the sell date in the database. Since user sells based on yesterday's data, we need to add yesterday's date instead for everything to work. Updated to use the already existing latestDate function in the investment calculator instead.